### PR TITLE
Arg improvement and improved error handling

### DIFF
--- a/cmds/curlx.js
+++ b/cmds/curlx.js
@@ -5,6 +5,10 @@ const { execCurl } = require('../utils/execute-curl.js');
 
 module.exports = async (args, exec_str, db) => {
   let cx_response = await execCurl(exec_str);
+  if (!cx_response) {
+    outputResponse(`Error while executing ${exec_str}`);
+    return;
+  }
   outputResponseHeaders(cx_response.responseHeaders);
   outputResponse(cx_response.responseBody);
   if (cx_response.logData) {

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,7 +4,12 @@ const path = require('path');
 module.exports = {
   prettyPrint: function(output) {
     if (typeof output === 'string' || output instanceof String) {
-      output = JSON.parse(output);
+      try {
+        output = JSON.parse(output);
+      }
+      catch (err) {
+        // Do nothing; it may have already been parsed (if the JSON was a string and not an object)
+      }
     }
     return JSON.stringify(output, null, 2);
   },

--- a/utils/parse-curl.js
+++ b/utils/parse-curl.js
@@ -164,14 +164,21 @@ var parseCurlCommand = function (curlCommand) {
 }
 
 const sanitizeCurlArgs = function (args) {
-  curlCommand = 'curl ' + args.join(' ');
-  curlCommand = curlCommand.replace(/ -XPOST/, ' -X POST')
-  curlCommand = curlCommand.replace(/ -XGET/, ' -X GET')
-  curlCommand = curlCommand.replace(/ -XPUT/, ' -X PUT')
-  curlCommand = curlCommand.replace(/ -XPATCH/, ' -X PATCH')
-  curlCommand = curlCommand.replace(/ -XDELETE/, ' -X DELETE')
-  curlCommand = curlCommand.trim()
-  return curlCommand.split(' ').slice(1);
+  const regexp = /^-X(POST|GET|PUT|PATCH|DELETE)$/;
+  let sanitizedArgs = [];
+  
+  for (let argI in args) {
+    const arg = args[argI];
+    if (regexp.test(arg)) {
+      // Properly format args like `-XPOST` to `-X POST`
+      sanitizedArgs.push('-X');
+      sanitizedArgs.push(arg.match(regexp)[1]);
+      continue;
+    }
+    sanitizedArgs.push(arg);
+  }
+  
+  return sanitizedArgs;
 }
 
 module.exports = {


### PR DESCRIPTION
This improves error handling in a few places which are currently not being handled and causing the script to die, mostly on non-standard HTTP responses. This also fixes an issue with args that have spaces in them such as:

```sh
cx --cookie 'fullname=John Doe' ...
```

Which is incorrectly transformed into:

```sh
curl -i "--cookie" "fullname=John" "Doe" ...
```

See individual commit messages for more details.